### PR TITLE
Export functions and aliases (#19)

### DIFF
--- a/source/dotnetCli/dotnetCli.psd1
+++ b/source/dotnetCli/dotnetCli.psd1
@@ -62,7 +62,13 @@ FormatsToProcess = @()
 NestedModules = @()
  
 # Functions to export from this module
-#FunctionsToExport = '*'
+FunctionsToExport = @(
+    'dotnetbuild',
+    'dotnetclean',
+    'dotnetpublish',
+    'dotnetrestore',
+    'dotnettest'
+)
  
 # Cmdlets to export from this module
 #CmdletsToExport = '*'

--- a/source/dotnetCli/dotnetCli.psd1
+++ b/source/dotnetCli/dotnetCli.psd1
@@ -77,7 +77,15 @@ FunctionsToExport = @(
 VariablesToExport = '*'
  
 # Aliases to export from this module
-#AliasesToExport = '*'
+AliasesToExport = @(
+    'd'
+    'dn'
+    'dnc'
+    'dnr'
+    'dnb'
+    'dnt'
+    'dnp'
+)
  
 # List of all modules packaged with this module
 ModuleList = @()

--- a/source/gitUtils/gitUtils.psd1
+++ b/source/gitUtils/gitUtils.psd1
@@ -62,7 +62,15 @@ FormatsToProcess = @()
 NestedModules = @()
  
 # Functions to export from this module
-#FunctionsToExport = '*'
+FunctionsToExport = @(
+    'New-Branch',
+    'New-Feature',
+    'New-RemoteBranch',
+    'Update-BranchFromDevelop',
+    'Update-GitRepo',
+    'Update-GitSubmodule',
+    'Update-GitsubmoduleRemote'
+)
  
 # Cmdlets to export from this module
 #CmdletsToExport = '*'

--- a/source/gitUtils/gitUtils.psd1
+++ b/source/gitUtils/gitUtils.psd1
@@ -79,7 +79,11 @@ FunctionsToExport = @(
 VariablesToExport = @()
  
 # Aliases to export from this module
-#AliasesToExport = '*'
+AliasesToExport = @(
+    'g',
+    'update',
+    'updateSub'
+)
  
 # List of all modules packaged with this module
 ModuleList = @()

--- a/source/macAddressUtils/macAddressUtils.psd1
+++ b/source/macAddressUtils/macAddressUtils.psd1
@@ -62,10 +62,14 @@ FormatsToProcess = @()
 NestedModules = @()
  
 # Functions to export from this module
-#FunctionsToExport = '*'
+FunctionsToExport = @(
+    'Get-DefaultDocumentPath',
+    'Get-MacAddressVendor', 
+    'Update-MacAddressVendor' 
+)
  
 # Cmdlets to export from this module
-CmdletsToExport = @('Get-MacAddressVendor', 'Update-MacAddressVendor', 'Get-DefaultDocumentPath')
+# CmdletsToExport = '*'
  
 # Variables to export from this module
 VariablesToExport =  @()

--- a/source/posh-profile.psd1
+++ b/source/posh-profile.psd1
@@ -84,7 +84,20 @@ FunctionsToExport = @(
 VariablesToExport = @('msBuildVS2015', 'msBuildVS2017', 'msBuildVS2017Preview')
  
 # Aliases to export from this module
-#AliasesToExport = '*'
+AliasesToExport = @(
+    'tp'
+    'ripmo'
+    'hh'
+    'f'
+    'vim'
+    'vi'
+    'v'
+    'CA'
+    'PSCA'
+    'analyse'
+    'analyze'
+    'w'
+)
  
 # List of all modules packaged with this module
 ModuleList = @()

--- a/source/posh-profile.psd1
+++ b/source/posh-profile.psd1
@@ -65,7 +65,17 @@ FormatsToProcess = @()
 NestedModules = @()
  
 # Functions to export from this module
-#FunctionsToExport = '*'
+FunctionsToExport = @(
+    'b'
+    'e'
+    'gh'
+    'OpenProfileInExplorer'
+    'ReImport-Module'
+    'Save-History'
+    'Set-LocationToCurrentIseItem'
+    'touch'
+    'which'
+)
  
 # Cmdlets to export from this module
 #CmdletsToExport = '*'

--- a/source/poshprofileAliases.ps1
+++ b/source/poshprofileAliases.ps1
@@ -15,7 +15,6 @@ Set-Alias v vim
 Set-Alias CA Invoke-ScriptAnalyzer
 Set-Alias PSCA Invoke-ScriptAnalyzer
 Set-Alias analyse Invoke-ScriptAnalyzer
-Set-Alias analyse Invoke-ScriptAnalyzer
 Set-Alias analyze Invoke-ScriptAnalyzer
 
 Set-Alias w with # posh-with


### PR DESCRIPTION
#19 

Exported all functions and aliases that posh-profile declares.
The macAddressUtils were declared as cmdlets, but I've changed those to functions as `Get-Command | Where {$_.Source -eq 'macAddressUtils'}` returns them as functions